### PR TITLE
Introduce task error handling and reporting

### DIFF
--- a/workerpool/example/consumer.go
+++ b/workerpool/example/consumer.go
@@ -18,42 +18,44 @@ type consumer struct {
 	completed           uint64
 	workCompletedReal   uint64
 	workCompletedCanary uint64
+	rampDuration        time.Duration
 }
 
 // rampUp linearly in increasing increments of the 5 seconds. This function is
 // only called once when each consumer is first Run.
 func (c *consumer) rampUp() {
-	rampUpDur := time.Duration((c.tid)*5) * time.Second
-	c.log.Debug().Msgf("consumer[%d] waiting %s to start", c.tid, rampUpDur)
-	time.Sleep(rampUpDur)
+	c.log.Debug().Msgf("consumer[%d] waiting %s to start", c.tid, c.rampDuration)
+	time.Sleep(c.rampDuration)
 }
 
 // Run runs the consumer for each work task submitted by the producer.
-func (c *consumer) Run(ctx context.Context, tid workerpool.ThreadID) error {
+func (c *consumer) Run(ctx context.Context) error {
 	var once sync.Once
-	c.tid = tid
 
 EXIT:
 	for {
 		select {
 		case <-ctx.Done():
-			c.log.Debug().Msgf("consumer[%d]: shutting down", tid)
+			c.log.Debug().Msgf("consumer[%d]: shutting down", c.tid)
 			break EXIT
 		case t, ok := <-c.queue:
 			if !ok {
 				break EXIT // channel closed
 			}
+
+			// NOTE: this isn't just an example of ramp up but also any prestart
+			// function that only needs to run once initially for each consumer
 			once.Do(c.rampUp)
 
 			switch task := t.(type) {
 			case *taskReal:
-				c.log.Debug().Msgf("consumer[%d]: received real work task", tid)
+				c.log.Debug().Msgf("consumer[%d]: received real work task", c.tid)
 
 				task.DoWork()
 				task.finishFn()
 				c.workCompletedReal++
 			case *taskCanary:
-				c.log.Debug().Msgf("consumer[%d]: received canary work task", tid)
+				c.log.Debug().Msgf("consumer[%d]: received canary work task", c.tid)
 
 				task.DoWork()
 				task.finishFn()
@@ -64,7 +66,7 @@ EXIT:
 			c.completed++
 		}
 	}
-	c.log.Debug().Msgf("consumer[%d]: exiting: completed %d times\n", tid, c.completed)
+	c.log.Debug().Msgf("consumer[%d]: exiting: completed %d times\n", c.tid, c.completed)
 
 	return nil
 }

--- a/workerpool/example/consumer_factory.go
+++ b/workerpool/example/consumer_factory.go
@@ -12,14 +12,22 @@ type consumerFactory struct {
 	log zerolog.Logger
 
 	lock                sync.Mutex
-	completed           uint64
 	stalls              uint64
-	workCompletedCanary uint64
+	completed           uint64
+	errored             uint64
+	workRequested       uint64
 	workCompletedReal   uint64
+	workCompletedCanary uint64
+	workErrReal         uint64
+	workErrCanary       uint64
 }
 
 // rampFactor is a multiplier used to calculate the duration of initial ramp up
 const rampFactor = 5
+
+// rampUnit is the increment of time used to calculate the duration of initial
+// ramp up
+const rampUnit = 1 * time.Second
 
 func NewConsumerFactory(log zerolog.Logger) *consumerFactory {
 	return &consumerFactory{
@@ -32,7 +40,7 @@ func (cf *consumerFactory) New(tid workerpool.ThreadID, q workerpool.SubmissionQ
 		log:          cf.log,
 		tid:          tid,
 		queue:        q,
-		rampDuration: time.Duration(tid*rampFactor) * time.Second,
+		rampDuration: time.Duration(tid*rampFactor) * rampUnit,
 	}, nil
 }
 
@@ -43,6 +51,11 @@ func (cf *consumerFactory) Finished(tid workerpool.ThreadID, consumerIface worke
 	defer cf.lock.Unlock()
 
 	cf.workCompletedCanary += w.workCompletedCanary
-	cf.completed += w.completed
 	cf.workCompletedReal += w.workCompletedReal
+	cf.workErrCanary += w.workErrCanary
+	cf.workErrReal += w.workErrReal
+
+	cf.workRequested += w.workRequested
+	cf.completed += w.completed
+	cf.errored += w.workErrCanary + w.workErrReal
 }

--- a/workerpool/example/main.go
+++ b/workerpool/example/main.go
@@ -82,9 +82,13 @@ func realMain() int {
 	log.Info().Msg("finished waiting for consumers")
 
 	log.Info().Msgf("Work Submitted: %d", pf.submittedWork)
-	log.Info().Msgf("Work Completed: %d", cf.completed)
+	log.Info().Msgf("Total Requested: %d", cf.workRequested)
+	log.Info().Msgf("Total Completed: %d", cf.completed)
+	log.Info().Msgf("Total Errors: %d", cf.errored)
 	log.Info().Msgf("\tReal Work Completed:   %d", cf.workCompletedReal)
 	log.Info().Msgf("\tCanary Work Completed: %d", cf.workCompletedCanary)
+	log.Info().Msgf("\tReal Work Errors:   %d", cf.workErrReal)
+	log.Info().Msgf("\tCanary Work Errors: %d", cf.workErrCanary)
 	log.Info().Msgf("Producer Stalls: %d", pf.stalls)
 	log.Info().Msgf("Consumer Stalls: %d", cf.stalls)
 

--- a/workerpool/example/producer_factory.go
+++ b/workerpool/example/producer_factory.go
@@ -22,10 +22,11 @@ func NewProducerFactory(log zerolog.Logger) *producerFactory {
 	}
 }
 
-func (pf *producerFactory) New(q workerpool.SubmissionQueue) (workerpool.Producer, error) {
+func (pf *producerFactory) New(tid workerpool.ThreadID, q workerpool.SubmissionQueue) (workerpool.Producer, error) {
 	const maxRealTasks = 10
 	p := &producer{
 		log:             pf.log,
+		tid:             tid,
 		queue:           q,
 		pacingDuration:  1 * time.Millisecond,
 		backoffDuration: 100 * time.Millisecond,
@@ -36,7 +37,7 @@ func (pf *producerFactory) New(q workerpool.SubmissionQueue) (workerpool.Produce
 	return p, nil
 }
 
-func (pf *producerFactory) Finished(threadID workerpool.ThreadID, producerIface workerpool.Producer) {
+func (pf *producerFactory) Finished(tid workerpool.ThreadID, producerIface workerpool.Producer) {
 	p := producerIface.(*producer)
 
 	pf.lock.Lock()

--- a/workerpool/example/tasks.go
+++ b/workerpool/example/tasks.go
@@ -1,19 +1,42 @@
 package main
 
-import "time"
+import (
+	"errors"
+	"math/rand"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/sean-/patterns/workerpool"
+)
 
 type taskReal struct {
+	log zerolog.Logger
+
+	tid      workerpool.ThreadID
 	finishFn func()
 }
 
-func (rt *taskReal) DoWork() {
+func (rt *taskReal) DoWork() error {
 	time.Sleep(2 * time.Second)
+
+	if rand.Intn(5) == 1 {
+		return errors.New("randomly broke real task")
+	}
+	return nil
 }
 
 type taskCanary struct {
+	log zerolog.Logger
+
+	tid      workerpool.ThreadID
 	finishFn func()
 }
 
-func (ct *taskCanary) DoWork() {
+func (ct *taskCanary) DoWork() error {
 	time.Sleep(10 * time.Millisecond)
+
+	if rand.Intn(5) < 2 {
+		return errors.New("randomly broke canary task")
+	}
+	return nil
 }

--- a/workerpool/interfaces.go
+++ b/workerpool/interfaces.go
@@ -51,22 +51,22 @@ type SubmissionQueue chan Task
 
 // Producer is the producer of work across a pool of workers.
 type Producer interface {
-	Run(context.Context, ThreadID) error
+	Run(context.Context) error
 }
 
 // ProducerFactory handles the construction of a new Producer.
 type ProducerFactory interface {
-	New(SubmissionQueue) (Producer, error)
+	New(ThreadID, SubmissionQueue) (Producer, error)
 	Finished(ThreadID, Producer)
 }
 
 // Consumer executes a logical unit of work tasked by the Producer.
 type Consumer interface {
-	Run(context.Context, ThreadID) error
+	Run(context.Context) error
 }
 
 // ConsumerFactory handles the construction of a new Worker.
 type ConsumerFactory interface {
-	New(SubmissionQueue) (Consumer, error)
+	New(ThreadID, SubmissionQueue) (Consumer, error)
 	Finished(ThreadID, Consumer)
 }

--- a/workerpool/workerpool.go
+++ b/workerpool/workerpool.go
@@ -91,7 +91,7 @@ func (a *workerPool) StartProducers() error {
 		go func(i uint) {
 			defer a.producersWG.Done()
 			threadID := ThreadID(i)
-			producer, err := a.factories.ProducerFactory.New(a.submissionQueue)
+			producer, err := a.factories.ProducerFactory.New(threadID, a.submissionQueue)
 			if err != nil {
 				if a.handlers.ProducerFactoryNewErr == nil {
 					panic(fmt.Sprintf("error creating a new producer %d: %v", i, err))
@@ -100,7 +100,7 @@ func (a *workerPool) StartProducers() error {
 				a.handlers.ProducerFactoryNewErr(err)
 			}
 
-			if err := producer.Run(a.shutdownCtx, threadID); err != nil {
+			if err := producer.Run(a.shutdownCtx); err != nil {
 				if a.handlers.ProducerRunErr == nil {
 					panic(fmt.Sprintf("error starting producer thread %d: %v", i, err))
 				}
@@ -124,7 +124,7 @@ func (a *workerPool) StartConsumers() error {
 		go func(i uint) {
 			defer a.consumersWG.Done()
 			threadID := ThreadID(i)
-			consumer, err := a.factories.ConsumerFactory.New(a.submissionQueue)
+			consumer, err := a.factories.ConsumerFactory.New(threadID, a.submissionQueue)
 			if err != nil {
 				if a.handlers.ConsumerFactoryNewErr == nil {
 					panic(fmt.Sprintf("error creating a new consumer %d: %v", i, err))
@@ -133,7 +133,7 @@ func (a *workerPool) StartConsumers() error {
 				a.handlers.ConsumerFactoryNewErr(err)
 			}
 
-			if err := consumer.Run(a.shutdownCtx, threadID); err != nil {
+			if err := consumer.Run(a.shutdownCtx); err != nil {
 				if a.handlers.ConsumerRunErr == nil {
 					panic(fmt.Sprintf("error starting consumer thread %d: %v", i, err))
 				}


### PR DESCRIPTION
This includes #5 and needs to be rebased on top once that is merged otherwise this is pretty much self contained in the HEAD commit.

I'd like to add a workerpool wide circuit breaker to cancel shutdown context if `consumer_factory.errored > N` but I'm still looking into the best way to implement that.