### PR TITLE
Support shutdown after max errors

### DIFF
--- a/workerpool/example/consumer.go
+++ b/workerpool/example/consumer.go
@@ -53,30 +53,32 @@ EXIT:
 
 			switch task := t.(type) {
 			case *taskReal:
+				var err error
 				task.tid = c.tid
 				c.log.Debug().Msgf("consumer[%d]: received real work task", c.tid)
 
-				if err := task.DoWork(); err != nil {
+				if err = task.DoWork(); err != nil {
 					c.log.Error().Err(err).Msg("failed to send real request")
 					c.workErrReal++
-					task.finishFn()
+					task.finishFn(err)
 					continue
 				}
 
-				task.finishFn()
+				task.finishFn(err)
 				c.workCompletedReal++
 			case *taskCanary:
+				var err error
 				task.tid = c.tid
 				c.log.Debug().Msgf("consumer[%d]: received canary work task", c.tid)
 
-				if err := task.DoWork(); err != nil {
+				if err = task.DoWork(); err != nil {
 					c.log.Error().Err(err).Msg("failed to send real request")
 					c.workErrCanary++
-					task.finishFn()
+					task.finishFn(err)
 					continue
 				}
 
-				task.finishFn()
+				task.finishFn(err)
 				c.workCompletedCanary++
 			default:
 				panic(fmt.Sprintf("invalid type: %v", task))

--- a/workerpool/example/producer_factory.go
+++ b/workerpool/example/producer_factory.go
@@ -24,6 +24,8 @@ func NewProducerFactory(log zerolog.Logger) *producerFactory {
 
 func (pf *producerFactory) New(tid workerpool.ThreadID, q workerpool.SubmissionQueue) (workerpool.Producer, error) {
 	const maxRealTasks = 10
+	// NOTE: set this to initiate shutdown after a max number of task errors
+	const maxErrTasks = 0
 	p := &producer{
 		log:             pf.log,
 		tid:             tid,
@@ -32,7 +34,7 @@ func (pf *producerFactory) New(tid workerpool.ThreadID, q workerpool.SubmissionQ
 		backoffDuration: 100 * time.Millisecond,
 		maxRealTasks:    maxRealTasks,
 		maxCanaryTasks:  1000 - maxRealTasks,
-		maxErrTasks:     5,
+		maxErrTasks:     maxErrTasks,
 	}
 
 	return p, nil

--- a/workerpool/example/producer_factory.go
+++ b/workerpool/example/producer_factory.go
@@ -32,6 +32,7 @@ func (pf *producerFactory) New(tid workerpool.ThreadID, q workerpool.SubmissionQ
 		backoffDuration: 100 * time.Millisecond,
 		maxRealTasks:    maxRealTasks,
 		maxCanaryTasks:  1000 - maxRealTasks,
+		maxErrTasks:     5,
 	}
 
 	return p, nil

--- a/workerpool/example/tasks.go
+++ b/workerpool/example/tasks.go
@@ -13,7 +13,7 @@ type taskReal struct {
 	log zerolog.Logger
 
 	tid      workerpool.ThreadID
-	finishFn func()
+	finishFn func(error)
 }
 
 func (rt *taskReal) DoWork() error {
@@ -29,7 +29,7 @@ type taskCanary struct {
 	log zerolog.Logger
 
 	tid      workerpool.ThreadID
-	finishFn func()
+	finishFn func(error)
 }
 
 func (ct *taskCanary) DoWork() error {

--- a/workerpool/interfaces.go
+++ b/workerpool/interfaces.go
@@ -51,7 +51,7 @@ type SubmissionQueue chan Task
 
 // Producer is the producer of work across a pool of workers.
 type Producer interface {
-	Run(context.Context) error
+	Run(context.Context, context.CancelFunc) error
 }
 
 // ProducerFactory handles the construction of a new Producer.

--- a/workerpool/workerpool.go
+++ b/workerpool/workerpool.go
@@ -100,7 +100,7 @@ func (a *workerPool) StartProducers() error {
 				a.handlers.ProducerFactoryNewErr(err)
 			}
 
-			if err := producer.Run(a.shutdownCtx); err != nil {
+			if err := producer.Run(a.shutdownCtx, a.shutdownFunc); err != nil {
 				if a.handlers.ProducerRunErr == nil {
 					panic(fmt.Sprintf("error starting producer thread %d: %v", i, err))
 				}


### PR DESCRIPTION
I'm not 100% positive on whether or not this is the best implementation but passing along the context cancellation does allow the entire workerpool to shutdown after max errors are reached. This seems to work well given that we already have a mutex wrapping our task finish callbacks.