### PR TITLE
Introduce a new FSM pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 A collection of reusable Go patterns
 
+- [`fsm`](https://github.com/sean-/patterns/tree/master/fsm)
 - [`workerpool`](https://github.com/sean-/patterns/tree/master/workerpool)

--- a/fsm/README.md
+++ b/fsm/README.md
@@ -1,0 +1,9 @@
+# `fsm`
+
+A
+reusable
+[finite state machine](https://en.wikipedia.org/wiki/Finite-state_machine).
+
+See
+[`example/main.go`](https://github.com/sean-/patterns/blob/master/fsm/example/main.go) for
+details.

--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -23,7 +23,8 @@ func (b *Builder) SetLog(log zerolog.Logger) {
 	b.log = log
 }
 
-func (b *Builder) SetStart(s State) {
+// SetInitialState sets the initial state of the FSM when it is created.
+func (b *Builder) SetInitialState(s State) {
 	b.start = s
 }
 

--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -2,6 +2,7 @@ package fsm
 
 import "github.com/rs/zerolog"
 
+// Builder is used to construct a new FSM instance
 type Builder struct {
 	globalGuards []Guard
 	log          zerolog.Logger
@@ -10,15 +11,17 @@ type Builder struct {
 	transitions  []Transition
 }
 
+// NewBuilder creates a new FSM Builder.
 func NewBuilder() (*Builder, error) {
 	return &Builder{}, nil
 }
 
-// SetGlobalGuard sets the list of guards that are run on every transition.
+// SetGlobalGuards sets the list of guards that are run on every transition.
 func (b *Builder) SetGlobalGuards(g []Guard) {
 	b.globalGuards = g
 }
 
+// SetLog configures the builder and FSM to use the supplied logger
 func (b *Builder) SetLog(log zerolog.Logger) {
 	b.log = log
 }
@@ -28,15 +31,18 @@ func (b *Builder) SetInitialState(s State) {
 	b.start = s
 }
 
+// AddTransition adds a transition to the builder
 func (b *Builder) AddTransition(trans Transition) error {
 	b.transitions = append(b.transitions, trans)
 	return nil
 }
 
+// SetTransitions replaces all existing transitions with the supplied arguments.
 func (b *Builder) SetTransitions(transitions []Transition) {
 	b.transitions = transitions
 }
 
+// Build constructs a new FSM
 func (b *Builder) Build() (*FSM, error) {
 	transMap := make(_TransitionMap, len(b.transitions))
 

--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -1,0 +1,67 @@
+package fsm
+
+import "github.com/rs/zerolog"
+
+type Builder struct {
+	globalGuards []Guard
+	log          zerolog.Logger
+	start        State
+	states       []State
+	transitions  []Transition
+}
+
+func NewBuilder() (*Builder, error) {
+	return &Builder{}, nil
+}
+
+// SetGlobalGuard sets the list of guards that are run on every transition.
+func (b *Builder) SetGlobalGuards(g []Guard) {
+	b.globalGuards = g
+}
+
+func (b *Builder) SetLog(log zerolog.Logger) {
+	b.log = log
+}
+
+func (b *Builder) SetStart(s State) {
+	b.start = s
+}
+
+func (b *Builder) SetStates(s []State) {
+	b.states = s
+}
+
+func (b *Builder) AddTransition(trans Transition) error {
+	b.transitions = append(b.transitions, trans)
+	return nil
+}
+
+func (b *Builder) SetTransitions(transitions []Transition) {
+	b.transitions = transitions
+}
+
+func (b *Builder) Build() (*FSM, error) {
+	transMap := make(_TransitionMap, len(b.transitions))
+
+	for _, t := range b.transitions {
+		k := FromToTuple{
+			From: t.From,
+			To:   t.To,
+		}
+		transMap[k] = _Transition{
+			guards:         append([]Guard{}, t.Guards...),
+			onEnterActions: append([]EnterHandler{}, t.OnEnterToActions...),
+			onExitActions:  append([]ExitHandler{}, t.OnExitToActions...),
+		}
+	}
+
+	m := &FSM{
+		currentState: b.start,
+		globalGuards: append([]Guard{}, b.globalGuards...),
+		log:          b.log,
+		states:       b.states,
+		transitions:  transMap,
+	}
+
+	return m, nil
+}

--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -28,10 +28,6 @@ func (b *Builder) SetInitialState(s State) {
 	b.start = s
 }
 
-func (b *Builder) SetStates(s []State) {
-	b.states = s
-}
-
 func (b *Builder) AddTransition(trans Transition) error {
 	b.transitions = append(b.transitions, trans)
 	return nil

--- a/fsm/example/main.go
+++ b/fsm/example/main.go
@@ -15,31 +15,29 @@ func main() {
 	os.Exit(realMain())
 }
 
-type State int
+type _State int
 
 const (
-	stateInitializing State = iota
+	stateInitializing _State = iota
 	stateRunning
 	stateStopped
 )
 
-var states map[State]string
+var states map[_State]string
 
 func init() {
-	states = map[State]string{
+	states = map[_State]string{
 		stateInitializing: "initializing",
 		stateRunning:      "running",
 		stateStopped:      "stopped",
 	}
 }
 
-type States []State
-
-func (s State) ID() int {
+func (s _State) ID() int {
 	return int(s)
 }
 
-func (s State) Name() string {
+func (s _State) Name() string {
 	if str, found := states[s]; found {
 		return str
 	}
@@ -48,7 +46,7 @@ func (s State) Name() string {
 	return "unknown"
 }
 
-func (s State) MarshalZerologObject(e *zerolog.Event) {
+func (s _State) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("state", s.Name())
 }
 

--- a/fsm/example/main.go
+++ b/fsm/example/main.go
@@ -80,7 +80,7 @@ func realMain() int {
 	fb.SetStates([]fsm.State{
 		stateInitializing,
 	})
-	fb.SetStart(stateInitializing)
+	fb.SetInitialState(stateInitializing)
 	_ = fb.AddTransition(fsm.Transition{
 		From: stateInitializing,
 		To:   stateRunning,

--- a/fsm/example/main.go
+++ b/fsm/example/main.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/sean-/patterns/fsm"
+	"github.com/sean-/seed"
+	"github.com/sean-/sysexits"
+)
+
+func main() {
+	os.Exit(realMain())
+}
+
+type State int
+
+const (
+	stateInitializing State = iota
+	stateRunning
+	stateStopped
+)
+
+var states map[State]string
+
+func init() {
+	states = map[State]string{
+		stateInitializing: "initializing",
+		stateRunning:      "running",
+		stateStopped:      "stopped",
+	}
+}
+
+type States []State
+
+func (s State) ID() int {
+	return int(s)
+}
+
+func (s State) Name() string {
+	if str, found := states[s]; found {
+		return str
+	}
+
+	panic(fmt.Sprintf("unknown state: %v", s))
+	return "unknown"
+}
+
+func (s State) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("state", s.Name())
+}
+
+func realMain() int {
+	seed.MustInit()
+
+	const logTimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
+
+	zerolog.DurationFieldUnit = time.Microsecond
+	zerolog.DurationFieldInteger = true
+	zerolog.TimeFieldFormat = logTimeFormat
+
+	log := zerolog.New(zerolog.ConsoleWriter{Out: os.Stdout}).
+		With().Timestamp().Logger()
+
+	fb, err := fsm.NewBuilder()
+	if err != nil {
+		log.Error().Err(err).Msg("unable to create FSM Builder")
+		return sysexits.Software
+	}
+
+	fb.SetGlobalGuards([]fsm.Guard{
+		func(old, new fsm.State) error {
+			log.Debug().Object("old", old).Object("new", new).Msg("global guard fired")
+			return nil
+		},
+	})
+	fb.SetLog(log)
+	fb.SetStates([]fsm.State{
+		stateInitializing,
+	})
+	fb.SetStart(stateInitializing)
+	_ = fb.AddTransition(fsm.Transition{
+		From: stateInitializing,
+		To:   stateRunning,
+		Guards: []fsm.Guard{
+			func(old, new fsm.State) error {
+				log.Debug().Object("old", old).Object("new", new).Msg("transition guard fired")
+				return nil
+			},
+		},
+		OnEnterToActions: []fsm.EnterHandler{
+			func() {
+				log.Debug().Msg("entering running state")
+			},
+		},
+		OnExitToActions: []fsm.ExitHandler{
+			func() {
+				log.Debug().Msg("exiting running state")
+			},
+		},
+	})
+	_ = fb.AddTransition(fsm.Transition{
+		From: stateRunning,
+		To:   stateStopped,
+		OnEnterToActions: []fsm.EnterHandler{
+			func() {
+				log.Debug().Msg("entering stopped state")
+			},
+		},
+	})
+
+	m, err := fb.Build()
+	if err != nil {
+		log.Error().Err(err).Msg("unable to build FSM")
+		return sysexits.Software
+	}
+
+	for _, state := range m.States() {
+		log.Debug().Object("state", state).Msg("")
+	}
+
+	log.Debug().Object("current state", m.CurrentState()).Msg("")
+
+	for _, x := range m.Transitions() {
+		log.Debug().Object("from", x.From).Object("to", x.To).Msg("")
+	}
+
+	if err := m.Transition(stateStopped); err != nil {
+		log.Error().Err(err).Msg("failed to transition")
+	}
+
+	if err := m.Transition(stateRunning); err != nil {
+		log.Error().Err(err).Msg("failed to transition")
+	}
+
+	if err := m.Transition(stateStopped); err != nil {
+		log.Error().Err(err).Msg("failed to transition")
+	}
+
+	log.Debug().Object("current state", m.CurrentState()).Msg("")
+
+	log.Debug().Msg("done")
+
+	return sysexits.OK
+}

--- a/fsm/example/main.go
+++ b/fsm/example/main.go
@@ -77,9 +77,6 @@ func realMain() int {
 		},
 	})
 	fb.SetLog(log)
-	fb.SetStates([]fsm.State{
-		stateInitializing,
-	})
 	fb.SetInitialState(stateInitializing)
 	_ = fb.AddTransition(fsm.Transition{
 		From: stateInitializing,

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -1,0 +1,134 @@
+package fsm
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+type FromToTuple struct {
+	From State
+	To   State
+}
+
+type _Transition struct {
+	guards         []Guard
+	onEnterActions []EnterHandler
+	onExitActions  []ExitHandler
+}
+
+type _TransitionMap map[FromToTuple]_Transition
+
+type FSM struct {
+	currentState  State
+	onExitActions []ExitHandler
+	lock          sync.Mutex
+	globalGuards  []Guard
+	log           zerolog.Logger
+	states        []State
+	transitions   _TransitionMap
+}
+
+type State interface {
+	ID() int
+	MarshalZerologObject(e *zerolog.Event)
+	Name() string
+}
+
+type Transition struct {
+	From             State
+	To               State
+	Guards           []Guard
+	OnEnterToActions []EnterHandler
+	OnExitToActions  []ExitHandler
+}
+
+type EnterHandler func()
+type ExitHandler func()
+
+type Guard func(currState, newState State) error
+
+func (m *FSM) States() []State {
+	return m.states
+}
+
+func (m *FSM) Transitions() []FromToTuple {
+	ret := make([]FromToTuple, len(m.transitions))
+	var i int
+	for x := range m.transitions {
+		ret[i] = x.Copy()
+		i++
+	}
+
+	return ret
+}
+
+func (m *FSM) CurrentState() State {
+	return m.currentState
+}
+
+// Transition transitions the state of the FSM from one state to another.
+// Before transitioning, the FSM looks up to ensure that a given transition
+// exists.  If the transition exists, all registered guards are executed
+// sequentially and must succeed.  If a guard fails, the error from the guard is
+// returned from Transition.  Once all guards have run successfully, any exit
+// handlers are executed.  Once the exit handlers have finished, the state is
+// changed.  If there are any on-enter hooks, the entry hooks are executed
+// before the Transition returns.
+func (m *FSM) Transition(s State) error {
+	transKey := FromToTuple{From: m.currentState, To: s}
+
+	// For now, wrap the entire function in a single mutex.  Reentrant transition
+	// changes are not supported at this time.  I'm not sure how that would be
+	// modeled.
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	// 1. Ensure the transition exists
+	trans, found := m.transitions[transKey]
+	if !found {
+		return errors.Errorf("unable to transition from %v to %v", m.currentState, s)
+	}
+
+	m.log.Debug().Object("from", m.currentState).Object("to", s).Msg("transitioning")
+
+	// 2. Run global guards
+	for i, guard := range m.globalGuards {
+		err := guard(m.currentState, s)
+		if err != nil {
+			return errors.Wrapf(err, "unable to transition from %s to %s in global guard %d", m.currentState, s, i)
+		}
+	}
+
+	// 3. Run per-transition guards
+	for i, guard := range trans.guards {
+		err := guard(m.currentState, s)
+		if err != nil {
+			return errors.Wrapf(err, "unable to transition from %s to %s in transition guard %d", m.currentState, s, i)
+		}
+	}
+
+	// 4. Run the exit handlers, if any
+	for _, exitFunc := range m.onExitActions {
+		exitFunc()
+	}
+
+	// 5. Change the state
+	m.currentState = s
+	m.onExitActions = trans.onExitActions
+
+	// 6. Run the enter actions, if any
+	for _, enterFunc := range trans.onEnterActions {
+		enterFunc()
+	}
+
+	return nil
+}
+
+func (ftt FromToTuple) Copy() FromToTuple {
+	return FromToTuple{
+		From: ftt.From,
+		To:   ftt.To,
+	}
+}


### PR DESCRIPTION
Add a basic Finite State Machine pattern for use.  Transitions are serialized.  `fsm` has support for:

* Global state transition guards
* Per-Transition guards
* Per-Transition on-enter and on-exit action handlers