### PR TITLE
fsm: GetState and SetState via applying build to a Stater type

### DIFF
--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -1,6 +1,10 @@
 package fsm
 
-import "github.com/rs/zerolog"
+import (
+	"errors"
+
+	"github.com/rs/zerolog"
+)
 
 // Builder is used to construct a new FSM instance
 type Builder struct {
@@ -9,6 +13,7 @@ type Builder struct {
 	start        State
 	states       []State
 	transitions  []Transition
+	stater       Stater
 }
 
 // NewBuilder creates a new FSM Builder.
@@ -43,7 +48,11 @@ func (b *Builder) SetTransitions(transitions []Transition) {
 }
 
 // Build constructs a new FSM
-func (b *Builder) Build() (*FSM, error) {
+func (b *Builder) Build(stater Stater) (*FSM, error) {
+	if stater == nil {
+		return nil, errors.New("failed to pass stater type into build")
+	}
+
 	transMap := make(_TransitionMap, len(b.transitions))
 
 	for _, t := range b.transitions {
@@ -59,11 +68,12 @@ func (b *Builder) Build() (*FSM, error) {
 	}
 
 	m := &FSM{
-		currentState: b.start,
+		currentState: stater.GetState(),
 		globalGuards: append([]Guard{}, b.globalGuards...),
 		log:          b.log,
 		states:       b.states,
 		transitions:  transMap,
+		stater:       stater,
 	}
 
 	return m, nil

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -31,6 +31,7 @@ type FSM struct {
 	log           zerolog.Logger
 	states        []State
 	transitions   _TransitionMap
+	stater        Stater
 }
 
 // State interface specifies the required interface for a State in the FSM.
@@ -40,6 +41,12 @@ type State interface {
 	MarshalZerologObject(e *zerolog.Event)
 	// Name is the human-friendly name of the State
 	Name() string
+}
+
+// Stater defines an object that persists the state machine's resulting state.
+type Stater interface {
+	SetState(State) error
+	GetState() State
 }
 
 // Transition is a user-specified Transition.  From is the old state.  To is the
@@ -61,13 +68,13 @@ type Transition struct {
 }
 
 // EnterHandler is the On-Enter transition handler
-type EnterHandler func()
+type EnterHandler func(stater Stater)
 
 // ExitHandler is the On-Exit transition handler
-type ExitHandler func()
+type ExitHandler func(stater Stater)
 
 // Guard is the transition guard handler signature
-type Guard func(currState, newState State) error
+type Guard func(currState, newState State, stater Stater) error
 
 // States returns a list of known states
 func (m *FSM) States() []State {
@@ -96,6 +103,15 @@ func (m *FSM) CurrentState() State {
 	return m.currentState
 }
 
+// SetStater sets the Stater object that this FSM can manipulate when
+// transitioning between states.
+func (m *FSM) SetStater(stater Stater) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.stater = stater
+}
+
 // Transition transitions the state of the FSM from one state to another.
 // Before transitioning, the FSM looks up to ensure that a given transition
 // exists.  If the transition exists, all registered guards are executed
@@ -105,6 +121,13 @@ func (m *FSM) CurrentState() State {
 // changed.  If there are any on-enter hooks, the entry hooks are executed
 // before the Transition returns.
 func (m *FSM) Transition(s State) error {
+	if m.stater != nil {
+		if ss := m.stater.GetState(); ss != m.currentState {
+			return errors.Errorf("unable to transition stater without matching %v to %v",
+				ss, m.currentState)
+		}
+	}
+
 	transKey := FromToTuple{From: m.currentState, To: s}
 
 	// For now, wrap the entire function in a single mutex.  Reentrant transition
@@ -123,7 +146,7 @@ func (m *FSM) Transition(s State) error {
 
 	// 2. Run global guards
 	for i, guard := range m.globalGuards {
-		err := guard(m.currentState, s)
+		err := guard(m.currentState, s, m.stater)
 		if err != nil {
 			return errors.Wrapf(err, "unable to transition from %s to %s in global guard %d", m.currentState, s, i)
 		}
@@ -131,7 +154,7 @@ func (m *FSM) Transition(s State) error {
 
 	// 3. Run per-transition guards
 	for i, guard := range trans.guards {
-		err := guard(m.currentState, s)
+		err := guard(m.currentState, s, m.stater)
 		if err != nil {
 			return errors.Wrapf(err, "unable to transition from %s to %s in transition guard %d", m.currentState, s, i)
 		}
@@ -139,16 +162,23 @@ func (m *FSM) Transition(s State) error {
 
 	// 4. Run the exit handlers, if any
 	for _, exitFunc := range m.onExitActions {
-		exitFunc()
+		exitFunc(m.stater)
 	}
 
 	// 5. Change the state
 	m.currentState = s
+
+	// 6. Update state of Stater
+	if m.stater != nil {
+		m.stater.SetState(s)
+	}
+
+	// 7. Swap onExit handlers to the new state
 	m.onExitActions = trans.onExitActions
 
-	// 6. Run the enter actions, if any
+	// 8. Run the enter actions, if any
 	for _, enterFunc := range trans.onEnterActions {
-		enterFunc()
+		enterFunc(m.stater)
 	}
 
 	return nil


### PR DESCRIPTION
This commit adds a new `Stater` interface which is a type that is included during a `Builder.Build`. `Build` will use `Stater`'s `SetState` to set the resulting state after a `Transition`. Also, Build uses the `Stater`'s `GetState` to set the initial state for the `FSM`.

Also, this commit introduces `Stater` as an argument to all handler callback functions so that the Stater can be acted upon or have other serialized components of a `Transition` type be persisted as well.