### PR TITLE
Fixup state ID tracking

### DIFF
--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -1,13 +1,15 @@
 package fsm
 
-import "github.com/rs/zerolog"
+import (
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
 
 // Builder is used to construct a new FSM instance
 type Builder struct {
 	globalGuards []Guard
 	log          zerolog.Logger
 	start        State
-	states       []State
 	transitions  []Transition
 }
 
@@ -46,23 +48,57 @@ func (b *Builder) SetTransitions(transitions []Transition) {
 func (b *Builder) Build() (*FSM, error) {
 	transMap := make(_TransitionMap, len(b.transitions))
 
+	statesIDMap := make(map[StateID]State, 2*len(b.transitions))
+	statesNameMap := make(map[string]State, 2*len(b.transitions))
+
 	for _, t := range b.transitions {
-		k := FromToTuple{
-			From: t.From,
-			To:   t.To,
+		t := t
+		statesIDMap[t.From.ID()] = t.From
+		statesIDMap[t.To.ID()] = t.To
+		statesNameMap[t.From.String()] = t.From
+		statesNameMap[t.To.String()] = t.To
+
+		k := _FromIDToIDTuple{
+			From: t.From.ID(),
+			To:   t.To.ID(),
 		}
+
+		// Check to make sure we're not transitioning from one state to itself
+		if t.From.ID() == t.To.ID() {
+			return nil, errors.Errorf("unable to re-transition to the same state: from %q to %q", k.From, k.To)
+		}
+
+		// Check for duplicate IDs
+		if _, found := transMap[k]; found {
+			return nil, errors.Errorf("duplicate state transition found: from %q to %q", k.From, k.To)
+		}
+
+		// Check for state name reuse
+		if v, found := statesNameMap[t.From.String()]; found && v.ID() != t.From.ID() {
+			return nil, errors.Errorf("state name reused for a different ID: %q/%q", t.From.String(), t.From.ID())
+		} else if v, found := statesNameMap[t.To.String()]; found && v.ID() != t.To.ID() {
+			return nil, errors.Errorf("state name reused for a different ID: %q/%q", t.To.String(), t.To.ID())
+		}
+
 		transMap[k] = _Transition{
 			guards:         append([]Guard{}, t.Guards...),
 			onEnterActions: append([]EnterHandler{}, t.OnEnterToActions...),
 			onExitActions:  append([]ExitHandler{}, t.OnExitToActions...),
+			transition:     FromToTuple{From: t.From, To: t.To},
 		}
+	}
+
+	states := make([]State, 0, len(statesIDMap))
+	for _, s := range statesIDMap {
+		s := s
+		states = append(states, s)
 	}
 
 	m := &FSM{
 		currentState: b.start,
 		globalGuards: append([]Guard{}, b.globalGuards...),
 		log:          b.log,
-		states:       b.states,
+		states:       states,
 		transitions:  transMap,
 	}
 

--- a/fsm/builder.go
+++ b/fsm/builder.go
@@ -52,7 +52,6 @@ func (b *Builder) Build() (*FSM, error) {
 	statesNameMap := make(map[string]State, 2*len(b.transitions))
 
 	for _, t := range b.transitions {
-		t := t
 		statesIDMap[t.From.ID()] = t.From
 		statesIDMap[t.To.ID()] = t.To
 		statesNameMap[t.From.String()] = t.From
@@ -90,7 +89,6 @@ func (b *Builder) Build() (*FSM, error) {
 
 	states := make([]State, 0, len(statesIDMap))
 	for _, s := range statesIDMap {
-		s := s
 		states = append(states, s)
 	}
 

--- a/fsm/example/main.go
+++ b/fsm/example/main.go
@@ -15,7 +15,7 @@ func main() {
 	os.Exit(realMain())
 }
 
-type _State int
+type _State int64
 
 const (
 	stateInitializing _State = iota
@@ -33,8 +33,8 @@ func init() {
 	}
 }
 
-func (s _State) ID() int {
-	return int(s)
+func (s _State) ID() fsm.StateID {
+	return fsm.StateID(s)
 }
 
 func (s _State) String() string {

--- a/fsm/example/main.go
+++ b/fsm/example/main.go
@@ -37,7 +37,7 @@ func (s _State) ID() int {
 	return int(s)
 }
 
-func (s _State) Name() string {
+func (s _State) String() string {
 	if str, found := states[s]; found {
 		return str
 	}
@@ -47,7 +47,7 @@ func (s _State) Name() string {
 }
 
 func (s _State) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("state", s.Name())
+	e.Str("state", s.String())
 }
 
 func realMain() int {

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -38,8 +38,8 @@ type State interface {
 	// ID is a unique numeric ID representing a State
 	ID() int
 	MarshalZerologObject(e *zerolog.Event)
-	// Name is the human-friendly name of the State
-	Name() string
+	// String is the human-friendly name of the State
+	String() string
 }
 
 // Transition is a user-specified Transition.  From is the old state.  To is the


### PR DESCRIPTION
Guard against descriptor and name reuse for `State` transitions.  This isn't exhaustive, but should prevent the most common set of transition bugs.